### PR TITLE
Fix test assembly

### DIFF
--- a/Tests/Editor/iShape.Triangulation.Editor.Tests.asmdef
+++ b/Tests/Editor/iShape.Triangulation.Editor.Tests.asmdef
@@ -1,21 +1,23 @@
 {
     "name": "iShape.Triangulation.Editor.Tests",
+    "rootNamespace": "Tests.Triangulation",
     "references": [
-        "iShape.Triangulation",
-        "iShape.Geometry"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "iShape.Geometry",
+        "iShape.Triangulation"
     ],
     "includePlatforms": [
         "Editor"
     ],
-    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,
-    "precompiledReferences": [],
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": []
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
Fix compilation on 2022.3. Configure assembly according to: https://docs.unity3d.com/Packages/com.unity.test-framework@1.4/manual/workflow-create-test-assembly.html

- Add missing reference to "nunit.framework.dll".
- Define "UNITY_INCLUDE_TESTS".